### PR TITLE
Fix Individual LTI Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
-- If the VLE does not pass site category information to the blogging service, the blog will default to a course blog type
+- If the VLE does not pass site category information to the blogging service, the blog will default to a course blog type (PR #21)
+- Changed the `get_blog_id()` function to be called `get_blog_id_if_exists` to reduce the number of queries in the plugin by combining the `blog_exists()` and `get_blog_id` functions (PR #27, 28)
+
+### Removed
+- Remove unused function `get_blog_count()`. Also removed `blog_exists()` function from the blog handlers classes
 
 ### Fixed
-- Altered register_activation_hook to point to namespaced Ed_LTI class. Previously, the activation hook was only using class name (without namespace), which resulted in errors.
+- Altered register_activation_hook to point to namespaced Ed_LTI class. Previously, the activation hook was only using class name (without namespace), which resulted in errors (PR #26)
 
 ## [1.1.0] - 2018-12-05
 

--- a/classes/class-student-blog-handler.php
+++ b/classes/class-student-blog-handler.php
@@ -62,8 +62,10 @@ class Student_Blog_Handler extends Blog_Handler {
 			wp_die( 'Blog_Handler: You must set all data before calling first_or_create_blog' );
 		}
 
-		if ( $this->blog_exists() ) {
-			return $this->get_blog_id();
+		$blog_id = $this->get_blog_id_if_exists();
+
+		if ( null !== $blog_id ) {
+			return $blog_id;
 		}
 
 		// If the blog path already exists, this user must already have created a student blog already. However, their id must have changed. The most likely reason is that they were deleted from the system and then added again.


### PR DESCRIPTION
This fixes issue #28. In an earlier update, the function `blog_exists()` had been removed. This functions usage had been removed in the class blog handler but it remained in the individual blog handler. This PR fixes that omission.