### PR TITLE
Fix Caching for LTI Student Lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Instructors can now use a browser's back button to return to the LTI student list. Previously they would have been presented with a Document Expired message (PR #22)
 
 ## [1.2.0] - 2019-06-21
-
 ### Changed
 - If the VLE does not pass site category information to the blogging service, the blog will default to a course blog type (PR #21)
 - Changed the `get_blog_id()` function to be called `get_blog_id_if_exists` to reduce the number of queries in the plugin by combining the `blog_exists()` and `get_blog_id` functions (PR #27, 28)
@@ -19,13 +20,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Altered register_activation_hook to point to namespaced Ed_LTI class. Previously, the activation hook was only using class name (without namespace), which resulted in errors (PR #26)
 
 ## [1.1.0] - 2018-12-05
-
 ### Added
 - When the first admin user is added to a blog, set site admin_email option to their email address. (PR #20)
 - When user is made main admin (i.e the above) send a notification email to the user explaining as much. (PR #20)
 
 ## [1.0.1] - 2018-11-23
-
 ### Added
 - Added namespaces to all classes (PR #19)
 
@@ -33,9 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Removed lti prefixes from function names as no longer required (PR #19)
 
 ## [1.0.0] - 2018-10-30
-
 - First major release
-
 
 [Unreleased]: https://github.com/uoe-dlam/ed-lti/compare/v1.2.0...HEAD
 [1.2.0]: https://github.com/uoe-dlam/ed-lti/compare/v1.1.0...v1.2.0

--- a/classes/class-ed-lti.php
+++ b/classes/class-ed-lti.php
@@ -384,6 +384,9 @@ class Ed_LTI {
 		);
         // phpcs:enable
 
+        // Cache the response for 30 minutes
+        header('Cache-Control: private, max-age: 1800');
+
 		get_template_part( 'header' );
 
 		echo '<div style="width:80%; margin: 0 auto">';

--- a/classes/class-ed-lti.php
+++ b/classes/class-ed-lti.php
@@ -32,8 +32,8 @@ class Ed_LTI {
 
 		$this->wpdb = $wpdb;
 
-		add_action( 'parse_request', [ $this, 'do_launch' ] );
-		add_action( 'parse_request', [ $this, 'add_staff_to_student_blog' ] );
+		add_action( 'parse_request', array( $this, 'do_launch' ) );
+		add_action( 'parse_request', array( $this, 'add_staff_to_student_blog' ) );
 
 		new Settings();
 		new Config();
@@ -150,7 +150,7 @@ class Ed_LTI {
 			session_start();
 		}
 
-		$_SESSION = [];
+		$_SESSION = array();
 
 		session_destroy();
 		session_start();
@@ -178,13 +178,13 @@ class Ed_LTI {
 	private function get_user_data( Ed_Tool_Provider $tool ) {
 		$username = $this->get_username_from_request();
 
-		$user_data = [
+		$user_data = array(
 			'username'  => $username,
 			'email'     => $tool->user->email,
 			'firstname' => $tool->user->firstname,
 			'lastname'  => $tool->user->lastname,
 			'password'  => $this->random_string( 20, '0123456789ABCDEFGHIJKLMNOPQRSTUVWZYZabcdefghijklmnopqrstuvwxyz' ),
-		];
+		);
 
 		return $user_data;
 	}
@@ -373,7 +373,7 @@ class Ed_LTI {
 			. 'AND resource_link_id = %s '
 			. 'AND blog_type = %s';
 
-        // phpcs:disable
+                // phpcs:disable
 		$blogs = $this->wpdb->get_results(
 			$this->wpdb->prepare(
 				$query,
@@ -382,10 +382,10 @@ class Ed_LTI {
 				$blog_type
 			)
 		);
-        // phpcs:enable
+                // phpcs:enable
 
-        // Cache the response for 30 minutes
-        header('Cache-Control: private, max-age: 1800');
+		// Cache the response for 30 minutes
+		header( 'Cache-Control: private, max-age: 1800' );
 
 		get_template_part( 'header' );
 


### PR DESCRIPTION
At the moment, if you click on a student LTI link and you are an instructor, you are presented with a list of student blogs associated with that course and LTI link.

If you visit one of those blogs by clicking on a link, then press back on the browser, you will be presented with a _Document Expired_ page.

This PR adds caching for this page for up to 30 minutes so that if a user clicks back, they will be able to see the LTI student course blogs list again.