### PR TITLE
WordPress LTI Plugin For Blogs - Add notification email custom param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2020-06-28
+## [Unreleased]
 ### Added
 - The plugin will now use a custom notification email supplied by the upstream VLE to store as a WordPress option for student blogs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- The plugin will now use a custom notification email supplied by the upstream VLE to store as a WordPress option for student blogs
+- The plugin will now use a custom notification email supplied by the upstream VLE to store as a WordPress option for student blogs (PR #33)
 
 ## [1.2.1] - 2020-04-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] - 2020-06-28
+### Added
+- The plugin will now use a custom notification email supplied by the upstream VLE to store as a WordPress option for student blogs
 
 ## [1.2.1] - 2020-04-30
 ### Fixed

--- a/classes/class-blog-handler.php
+++ b/classes/class-blog-handler.php
@@ -124,11 +124,13 @@ abstract class Blog_Handler {
 	/**
 	 * Manage additional blog options when a blog is created or viewed
 	 *
-	 * @return string
+	 * @param array $options_to_set
+	 *
+	 * @return void
 	 */
-	public function set_additional_blog_options( array $options_to_set ) {
+	public function set_additional_blog_options( array $options_to_set ): void {
 		foreach ( $options_to_set as $blog_option_key => $blog_option_value ) {
-			return update_blog_option( $this->blog_id, $blog_option_key, $blog_option_value );
+			update_blog_option( $this->blog_id, $blog_option_key, $blog_option_value );
 		}
 	}
 

--- a/classes/class-blog-handler.php
+++ b/classes/class-blog-handler.php
@@ -70,12 +70,12 @@ abstract class Blog_Handler {
 	abstract public function get_options_from_request( array $request_data ): array;
 
 	/**
-	 * Allow blog to be retrieved from path,
+	 * Allow blog id to be set from path,
 	 * as there is an issue should settings change.
 	 *
-	 * @return int|null The blog id, if found, or null
+	 * @return void
 	 */
-	abstract public function get_blog_from_path_fix(): ?int;
+	abstract protected function fix_blog_id_from_path(): void;
 
 	/**
 	 * Set class properties using array.
@@ -108,7 +108,8 @@ abstract class Blog_Handler {
 		$blog_id = $this->get_blog_id_if_exists();
 
 		if ( null === $blog_id ) {
-			$blog_id = $this->get_blog_from_path_fix();
+			$this->fix_blog_id_from_path();
+			$blog_id = $this->get_blog_id_if_exists();
 		}
 
 		if ( null === $blog_id ) {

--- a/classes/class-blog-handler.php
+++ b/classes/class-blog-handler.php
@@ -128,7 +128,7 @@ abstract class Blog_Handler {
 	 *
 	 * @return void
 	 */
-	public function set_additional_blog_options( array $options_to_set ): void {
+	public function set_additional_blog_options( array $options_to_set ) {
 		foreach ( $options_to_set as $blog_option_key => $blog_option_value ) {
 			update_blog_option( $this->blog_id, $blog_option_key, $blog_option_value );
 		}

--- a/classes/class-blog-handler.php
+++ b/classes/class-blog-handler.php
@@ -271,7 +271,7 @@ abstract class Blog_Handler {
 	 */
 	public function get_friendly_path( $path ) {
 		$path = str_replace( ' ', '-', $path ); // Replaces all spaces with hyphens.
-		$path = preg_replace( '/[^A-Za-z0-9\-\_]/', '', $path ); // Removes special chars.
+		$path = preg_replace( '/[^A-Za-z0-9\-_]/', '', $path ); // Removes special chars.
 		$path = strtolower( $path ); // Convert to lowercase.
 
 		if ( $this->is_subdirectory_install() ) {

--- a/classes/class-course-blog-handler.php
+++ b/classes/class-course-blog-handler.php
@@ -125,9 +125,8 @@ class Course_Blog_Handler extends Blog_Handler {
 	/**
 	 * Implement an abstract, but not required for course blogs
 	 *
-	 * @return int|null The blog id, if found, or null
+	 *@return void
 	 */
-	public function get_blog_from_path_fix(): ?int {
-		return null;
-	}
+	protected function fix_blog_id_from_path(): void {}
+
 }

--- a/classes/class-course-blog-handler.php
+++ b/classes/class-course-blog-handler.php
@@ -110,4 +110,24 @@ class Course_Blog_Handler extends Blog_Handler {
 
 		return $wordpress_user_role;
 	}
+
+	/**
+	 * Gets the blog options to set when the blog is created or loaded
+	 *
+	 * @param array   $request_data
+	 *
+	 * @return array
+	 */
+	public function get_options_from_request( array $request_data ): array {
+		return array();
+	}
+
+	/**
+	 * Implement an abstract, but not required for course blogs
+	 *
+	 * @return int|null The blog id, if found, or null
+	 */
+	public function get_blog_from_path_fix(): ?int {
+		return null;
+	}
 }

--- a/classes/class-ed-lti.php
+++ b/classes/class-ed-lti.php
@@ -23,7 +23,7 @@ use IMSGlobal\LTI\ToolProvider\DataConnector\DataConnector;
 
 class Ed_LTI {
 
-	const COURSE_SITE_CATEGORY_ID = 2;
+	private const COURSE_SITE_CATEGORY_ID = 2;
 
 	private $wpdb;
 
@@ -84,7 +84,7 @@ class Ed_LTI {
 			}
 
             // phpcs:disable
-			$blog_type = isset( $_REQUEST['custom_blog_type'] ) ? $_REQUEST['custom_blog_type'] : '';
+			$blog_type = $_REQUEST['custom_blog_type'] ?? '';
             // phpcs:enable
 
 			if ( $this->is_student_blog_and_non_student( $blog_type, $tool ) ) {
@@ -220,7 +220,7 @@ class Ed_LTI {
 	 */
 	private function get_site_data() {
         // phpcs:disable
-		$site_category = isset( $_REQUEST['custom_site_category'] )  ? $_REQUEST['custom_site_category'] :  self::COURSE_SITE_CATEGORY_ID;
+		$site_category = $_REQUEST['custom_site_category'] ?? self::COURSE_SITE_CATEGORY_ID;
 
         $username = $this->get_username_from_request();
 

--- a/classes/class-ed-lti.php
+++ b/classes/class-ed-lti.php
@@ -113,6 +113,7 @@ class Ed_LTI {
 			$user_roles = new User_LTI_Roles( $tool->user->roles );
 			$blog_handler->add_user_to_blog( $user, $blog_id, $user_roles );
 			$blog_handler->add_user_to_top_level_blog( $user );
+			$blog_handler->set_additional_blog_options( $blog_handler->get_options_from_request( $_REQUEST ) );
 
 			$this->signin_user( $user, $blog_id );
 		}

--- a/classes/class-ed-lti.php
+++ b/classes/class-ed-lti.php
@@ -177,17 +177,13 @@ class Ed_LTI {
 	 * @return array
 	 */
 	private function get_user_data( Ed_Tool_Provider $tool ) {
-		$username = $this->get_username_from_request();
-
-		$user_data = array(
-			'username'  => $username,
+		return array(
+			'username'  => $this->get_username_from_request(),
 			'email'     => $tool->user->email,
 			'firstname' => $tool->user->firstname,
 			'lastname'  => $tool->user->lastname,
 			'password'  => $this->random_string( 20, '0123456789ABCDEFGHIJKLMNOPQRSTUVWZYZabcdefghijklmnopqrstuvwxyz' ),
 		);
-
-		return $user_data;
 	}
 
 	/**

--- a/classes/class-student-blog-handler.php
+++ b/classes/class-student-blog-handler.php
@@ -50,20 +50,17 @@ class Student_Blog_Handler extends Blog_Handler {
 	 * due to a parameter changing since creation.
 	 *
 	 * If so, this function looks to find the blog from the path,
-	 * fixup the blog data and return the ID.
+	 * and fixup the blog data
 	 *
-	 * @return int|null The blog id, if found, or null
+	 * @return void
 	 */
-	public function get_blog_from_path_fix(): ?int {
+	public function fix_blog_id_from_path(): void {
 
 		$blog_id = $this->get_blog_id_for_path();
 
 		if ( null !== $blog_id ) {
 			$this->update_blog_meta_with_user_id( $blog_id );
-			$blog_id = $this->get_blog_id_if_exists();
 		}
-
-		return $blog_id;
 	}
 
 	/**

--- a/classes/class-student-blog-handler.php
+++ b/classes/class-student-blog-handler.php
@@ -46,37 +46,24 @@ class Student_Blog_Handler extends Blog_Handler {
 	}
 
 	/**
-	 * Create or return the existing blog.
-	 * Note that we are overidding the parent method for this class.
+	 * For student courses, the id might not be found using the standard search,
+	 * due to a parameter changing since creation.
 	 *
-	 * @param bool $make_private
+	 * If so, this function looks to find the blog from the path,
+	 * fixup the blog data and return the ID.
 	 *
-	 * @return int
+	 * @return int|null The blog id, if found, or null
 	 */
-	public function first_or_create_blog( $make_private = false ) {
-		if (
-			null === $this->course_id || null === $this->course_title || null === $this->domain ||
-			null === $this->resource_link_id || null === $this->username || null === $this->source_id ||
-			null === $this->site_category
-		) {
-			wp_die( 'Blog_Handler: You must set all data before calling first_or_create_blog' );
-		}
+	public function get_blog_from_path_fix(): ?int {
 
-		$blog_id = $this->get_blog_id_if_exists();
-
-		if ( null !== $blog_id ) {
-			return $blog_id;
-		}
-
-		// If the blog path already exists, this user must already have created a student blog already. However, their id must have changed. The most likely reason is that they were deleted from the system and then added again.
 		$blog_id = $this->get_blog_id_for_path();
 
-		if ( ! empty( $blog_id ) ) {
+		if ( null !== $blog_id ) {
 			$this->update_blog_meta_with_user_id( $blog_id );
-			return $this->get_blog_id();
+			$blog_id = $this->get_blog_id_if_exists();
 		}
 
-		return $this->create_blog( $make_private );
+		return $blog_id;
 	}
 
 	/**
@@ -140,9 +127,9 @@ class Student_Blog_Handler extends Blog_Handler {
 	}
 
 	/**
-	 * Get blog id for a given path. If no match 0 is returned.
+	 * Get blog id for a given path. If no match null is returned.
 	 *
-	 * @return int
+	 * @return int|null
 	 */
 	protected function get_blog_id_for_path() {
 		$path    = $this->get_path();
@@ -156,7 +143,9 @@ class Student_Blog_Handler extends Blog_Handler {
 
 		$path = '/' . $path . '/';
 
-		return get_blog_id_from_url( $this->domain, $path );
+		$blog_id = get_blog_id_from_url( $this->domain, $path );
+
+		return 0 === $blog_id ? null : $blog_id;
 	}
 
 	/**
@@ -187,5 +176,23 @@ class Student_Blog_Handler extends Blog_Handler {
 		}
 
 		return 'author';
+	}
+
+	/**
+	 * Gets the blog options to set when the blog is created or loaded
+	 *
+	 * @param array   $request_data
+	 *
+	 * @return array
+	 */
+	public function get_options_from_request( array $request_data ): array {
+		$options = array();
+
+		$notification_email = $request_data['custom_notification_email'] ?? false;
+		if ( $notification_email ) {
+			$options['notification_email'] = $notification_email;
+		}
+
+		return $options;
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
 	"require" : {
-		"imsglobal/lti": "*"
-	}
+		"imsglobal/lti": "*",
+      "ext-pdo": "*"
+    }
 }


### PR DESCRIPTION
Allow a custom notification_email value to be retrieved from the upstream LTI Provider and stored against a 'student' blog.

-----

* Refactor first_or_create_blog so student can use the base function, but the student case for checking path fix is retained as a separate function.
 * Student Blog get_blog_id_for_path returns null if not found, not 0, for consistency.
 * When the blog is loaded or created, the required blog options are set.
   * This allows the notification email to be set from the request for student blogs.
   * It is set every time a student loads the blog, to listen for any changes to email address from upstream.
   * This behaviour can be amended to update on change, or on create.
   * Uses wp_options table rather than the plugin blogs meta so no database amends are required.