### PR TITLE
WordPress LTI Plugin For Blogs - Add notification email custom param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - The plugin will now use a custom notification email supplied by the upstream VLE to store as a WordPress option for student blogs (PR #33)
+- The plugin will update the notification email to null if no, or an empty value, is sent.
 
 ## [1.2.1] - 2020-04-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - The plugin will now use a custom notification email supplied by the upstream VLE to store as a WordPress option for student blogs (PR #33)
-- The plugin will update the notification email to null if no, or an empty value, is sent.
+- The plugin will update the notification email to null if no, or an empty value, is sent. (PR #34)
 
 ## [1.2.1] - 2020-04-30
 ### Fixed

--- a/classes/class-student-blog-handler.php
+++ b/classes/class-student-blog-handler.php
@@ -185,10 +185,8 @@ class Student_Blog_Handler extends Blog_Handler {
 	public function get_options_from_request( array $request_data ): array {
 		$options = array();
 
-		$notification_email = $request_data['custom_notification_email'] ?? false;
-		if ( $notification_email ) {
-			$options['notification_email'] = $notification_email;
-		}
+		$notification_email            = $request_data['custom_notification_email'] ?? false;
+		$options['notification_email'] = $notification_email;
 
 		return $options;
 	}


### PR DESCRIPTION
 * Allow no or empty values sent for the notification custom parameter to update the blog option value.